### PR TITLE
Update text #48

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -68,7 +68,7 @@ ___
 
 **Your data Sources are the different places where data lies. These could be Google Sheets, KoboToolbox, Avni, or CommCare to name a few. Dalgo can connect to over 300 data sources. _We also develop connectors for new sources to meet your needs_.**
 
-**Set up the service account key**
+**If your spreadsheet is viewable by anyone with its link, no further action is needed. If not, give your Service account access to your spreadsheet.**
 
 **Create a service account**
 


### PR DESCRIPTION
Remove setup service account key information
[#48](https://github.com/DalgoT4D/dalgo_docs/issues/48)

Updated text from: Set up the service account key
To: If your spreadsheet is viewable by anyone with its link, no further action is needed. If not, [give your Service account access to your spreadsheet](https://youtu.be/GyomEw5a2NQ%22).