### PR TITLE
docs: update User Management for RBAC v2 role collapse

### DIFF
--- a/docs/settings/user-management.md
+++ b/docs/settings/user-management.md
@@ -21,7 +21,7 @@ You will see two tabs:
 
 1. Select **Invite User** in the top-right corner.
 2. Enter the user's **Email** address.
-3. Select a **Role** from the dropdown.
+3. Select a **Role** from the dropdown — **Admin**, **Analyst**, or **Member**.
 4. Select **Send Invitation**.
 
 The user will receive an invitation email. They appear under **Pending Invitations** until they accept and set up their account.
@@ -45,12 +45,22 @@ Removing a user immediately revokes their access to Dalgo. They will not be able
 
 ## Available roles
 
-| Role | User management | Warehouse | Sources | Connections | Transform | Orchestrate | Usage dashboard |
-|---|---|---|---|---|---|---|---|
-| Account Manager | Update | Update | Update | Update | Update | Update | View |
-| Pipeline Manager | View | View | Update | Update | Update | Update | View |
-| Analyst | View | View | View | View | Update | View | View |
-| Guest | View | View | View | View | View | View | View |
+Every user gets one of three roles:
+
+| | Admin | Analyst | Member |
+|---|---|---|---|
+| Dashboards, Charts, Reports, Metrics, KPIs, Alerts | Create, edit, delete anyone's | Create and edit; delete their own (an Admin can delete any) | View only |
+| Ingest, Transform, Orchestrate, Explore, Data Quality, Pipeline Overview | Full access | View only | Not shown |
+| Impact and KPIs summary pages | Full access | Full access | View only |
+| User Management and Billing | Full access | No access | No access |
+
+- **Analysts build, but don't connect or run.** They can create dashboards, charts, reports, metrics, KPIs, and alerts freely, and can see (but not change) your warehouse, sources, and transform setup.
+- **Deleting is owner-or-admin.** Anyone can delete the dashboards, charts, reports, metrics, KPIs, and alerts they created themselves. Deleting something a teammate made requires the Admin role.
+- **Members have a read-only view** of the dashboards, charts, reports, and alerts shared with the organisation, plus the Impact and KPIs pages.
+
+:::note
+Dalgo recently simplified its roles. If your organisation was already using Dalgo, existing users were moved over automatically: **Account Manager** and **Pipeline Manager** became **Admin**, and **Guest** became **Member** — **Analyst** keeps its name but no longer edits sources, connections, dbt models, or pipelines directly. Each user sees a one-time screen explaining what changed for their role the first time they log in after the update.
+:::
 
 ---
 

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -34,7 +34,7 @@ If the pipeline is running successfully but charts still look stale, the dashboa
 ## I didn't receive my invitation email
 
 1. Check your spam folder for an email from **notifications@dalgo.org**.
-2. If it's not there, ask an Account Manager in your organisation to resend the invitation from **Settings → User Management → Pending Invitations**.
+2. If it's not there, ask an Admin in your organisation to resend the invitation from **Settings → User Management → Pending Invitations**.
 
 ## I see "No pipelines available" on the Overview
 


### PR DESCRIPTION
## Summary
- Dalgo's RBAC is being simplified from four roles to three (`admin` / `analyst` / `member`, plus an internal `super-admin`): **Account Manager** and **Pipeline Manager** merge into **Admin**, **Guest** is renamed to **Member**, and **Analyst** loses direct write access to sources/connections/dbt models/pipelines while keeping full content authoring (dashboards, charts, reports, metrics, KPIs, alerts) and view-only infra access.
- Replaces the stale 4-role capability table in `docs/settings/user-management.md` with the new 3-role breakdown, documents the owner-or-admin delete rule, and adds a note explaining the automatic role migration for existing orgs.
- Fixes a leftover "Account Manager" reference in `docs/support/troubleshooting.md`.

## Notes for reviewers
- Verified against the final state of the `feature/rbac` branch in `DDP_backend`/`webapp_v2` (not just commit messages — the branch had two in-flight reversals, so I cross-checked `test_rbac_v2_roles.py`, `main-layout.tsx`, and the product's own onboarding-carousel copy in `onboarding/constants.ts` for the authoritative final permissions).
- That branch is **not yet merged**. This doc update is written for whenever it ships — happy to hold the PR if you'd rather merge docs only after the feature lands.
- The existing screenshots (`user_management.png`, `user_management_invite.png`) still show the old role names in the UI since they predate the RBAC change — worth a re-capture once the feature is live.

## Test plan
- [x] Ran `yarn install` + `docusaurus start` locally and confirmed the page renders with correct breadcrumb, table, and admonitions
- [x] Confirmed sidebar prev/next order (Branding → User Management → Billing) is unaffected
- [ ] Re-capture screenshots once RBAC v2 ships to production